### PR TITLE
Harden full-stack runtime env switching for S18 integration

### DIFF
--- a/deployment/docker/.env.full.llama-cpp-host
+++ b/deployment/docker/.env.full.llama-cpp-host
@@ -1,0 +1,13 @@
+VITE_SUPABASE_URL=https://lfjihuzcshjpggtdrtne.supabase.co
+VITE_SUPABASE_ANON_KEY=sb_publishable_VdhxbJsy2M4EZrHF77DQ8g_65HTEosc
+VITE_API_URL=http://localhost:8000
+
+# Full-stack runtime mode: llama.cpp for chat; Ollama kept for embeddings/RemMe.
+S18_PROFILE=local-llama-cpp
+LLAMA_CPP_BASE_URL=http://host.docker.internal:8080
+LLAMA_CPP_TIMEOUT=360
+OLLAMA_BASE_URL=http://s18share-ollama:11434
+OLLAMA_TIMEOUT=360
+
+# Optional if layout differs from sibling ../S18Share/S18Share
+# S18_PATH=../../../S18Share/S18Share

--- a/deployment/docker/.env.full.ollama
+++ b/deployment/docker/.env.full.ollama
@@ -1,0 +1,13 @@
+VITE_SUPABASE_URL=https://lfjihuzcshjpggtdrtne.supabase.co
+VITE_SUPABASE_ANON_KEY=sb_publishable_VdhxbJsy2M4EZrHF77DQ8g_65HTEosc
+VITE_API_URL=http://localhost:8000
+
+# Full-stack runtime mode: Ollama for chat + embeddings.
+S18_PROFILE=local-laptop-gemma
+OLLAMA_BASE_URL=http://s18share-ollama:11434
+OLLAMA_TIMEOUT=360
+LLAMA_CPP_BASE_URL=http://host.docker.internal:8080
+LLAMA_CPP_TIMEOUT=360
+
+# Optional if layout differs from sibling ../S18Share/S18Share
+# S18_PATH=../../../S18Share/S18Share

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -38,13 +38,13 @@ To run wise-ai with S18 (EHR Data Miner integration) in one command:
 
 ```bash
 cd deployment/docker
-docker compose -f docker-compose.full.yml up -d
+docker compose --env-file .env.full.ollama -f docker-compose.full.yml up -d
 ```
 
 **Prerequisite:** S18Share must be a sibling of wise-ai (e.g. `Downloads/wise-ai` and `Downloads/S18Share`). If your layout differs, set `S18_PATH`:
 
 ```bash
-S18_PATH=/path/to/S18Share/S18Share docker compose -f docker-compose.full.yml up -d
+S18_PATH=/path/to/S18Share/S18Share docker compose --env-file .env.full.ollama -f docker-compose.full.yml up -d
 ```
 
 This starts:
@@ -53,6 +53,29 @@ This starts:
 - **ollama** for S18 (port 11434)
 
 S18's mockehr uses `WISE_MOCKEHR_BASE_URL=http://backend:8000` to fetch patient data and labs from wise-ai's Mock EHR API.
+
+### Runtime mode switching (safe)
+
+Use dedicated env files instead of repeatedly mutating a shared `.env`:
+
+- `.env.full.ollama` -> Ollama runtime (`S18_PROFILE=local-laptop-gemma`)
+- `.env.full.llama-cpp-host` -> llama.cpp on host (`S18_PROFILE=local-llama-cpp`)
+
+PowerShell helper:
+
+```powershell
+cd deployment/docker
+.\run-full-stack.ps1 -Mode ollama -Build
+# or
+.\run-full-stack.ps1 -Mode llama_cpp_host -Build
+```
+
+Equivalent direct commands:
+
+```bash
+docker compose --env-file .env.full.ollama -f docker-compose.full.yml up -d --build
+docker compose --env-file .env.full.llama-cpp-host -f docker-compose.full.yml up -d --build
+```
 
 ---
 

--- a/deployment/docker/docker-compose.full.yml
+++ b/deployment/docker/docker-compose.full.yml
@@ -58,8 +58,11 @@ services:
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - AUTH_ENABLED=${S18_AUTH_ENABLED:-false}
-      - OLLAMA_BASE_URL=http://s18share-ollama:11434
+      - S18_PROFILE=${S18_PROFILE:-local-laptop-gemma}
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://s18share-ollama:11434}
       - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT:-300}
+      - LLAMA_CPP_BASE_URL=${LLAMA_CPP_BASE_URL:-http://host.docker.internal:8080}
+      - LLAMA_CPP_TIMEOUT=${LLAMA_CPP_TIMEOUT:-360}
       # Align advertised /runs poll hint with wise-ai client (optional; wise-ai uses its own poll loop).
       - RUN_POLL_TIMEOUT_SECONDS=${RUN_POLL_TIMEOUT_SECONDS:-900}
       - WISE_MOCKEHR_BASE_URL=http://backend:8000

--- a/deployment/docker/run-full-stack.ps1
+++ b/deployment/docker/run-full-stack.ps1
@@ -1,0 +1,43 @@
+param(
+    [ValidateSet("ollama", "llama_cpp_host")]
+    [string]$Mode = "ollama",
+    [switch]$Build
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$ComposeDir = Resolve-Path $PSScriptRoot
+
+$envFile = if ($Mode -eq "llama_cpp_host") {
+    Join-Path $ComposeDir ".env.full.llama-cpp-host"
+}
+else {
+    Join-Path $ComposeDir ".env.full.ollama"
+}
+
+if (-not (Test-Path $envFile)) {
+    throw "Missing env file: $envFile"
+}
+
+Push-Location $ComposeDir
+try {
+    $args = @("--env-file", $envFile, "-f", "docker-compose.full.yml", "up", "-d")
+    if ($Build) {
+        $args = @("--env-file", $envFile, "-f", "docker-compose.full.yml", "up", "-d", "--build")
+    }
+    & docker compose @args
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "Full stack started with mode '$Mode'."
+Write-Host "Env file: $envFile"
+if ($Mode -eq "llama_cpp_host") {
+    Write-Host "Expect host llama-server at http://host.docker.internal:8080"
+}
+else {
+    Write-Host "Using bundled s18share-ollama at http://s18share-ollama:11434"
+}


### PR DESCRIPTION
﻿## Summary
- add explicit full-stack env profiles for Ollama and host llama.cpp runtime modes
- wire compose variables so `s18share-api` receives provider URLs/timeouts consistently
- add a single launcher script (`deployment/docker/run-full-stack.ps1`) to boot the stack by mode

## Test plan
- [x] `powershell -ExecutionPolicy Bypass -File deployment/docker/run-full-stack.ps1 -Mode ollama`
- [x] `powershell -ExecutionPolicy Bypass -File deployment/docker/run-full-stack.ps1 -Mode llama_cpp_host`
- [x] confirm Wise backend boots with `.env` values and can reach S18 health endpoint
